### PR TITLE
Added Unique Id to clients and Packets, ClientJoined, ClientLeft and broadcast

### DIFF
--- a/Brawler-server/Server/Client.cs
+++ b/Brawler-server/Server/Client.cs
@@ -9,6 +9,7 @@ namespace BrawlerServer.Server
     {
         public IPEndPoint EndPoint { get; private set; }
         public string Name { get; private set; }
+        public uint Id { get; private set; }
 
         public Client(IPEndPoint endPoint, string name)
         {

--- a/Brawler-server/Server/LeaveHandler.cs
+++ b/Brawler-server/Server/LeaveHandler.cs
@@ -29,7 +29,7 @@ namespace BrawlerServer.Server
             Logs.Log($"[{packet.Server.Time}] Received leave message from '{packet.RemoteEp}'.");
             // create client and add it to the server's clients
             Client = packet.Server.GetClientFromEndPoint(packet.RemoteEp);
-            packet.Server.RemoveClient(packet.RemoteEp);
+            packet.Server.RemoveClient(packet.RemoteEp, "left the game");
             Logs.Log($"[{packet.Server.Time}] Player with remoteEp '{packet.RemoteEp}' (a.k.a. {JsonData.Name}) left the server");
         }
     }

--- a/Brawler-server/Utilities/Utilities.cs
+++ b/Brawler-server/Utilities/Utilities.cs
@@ -6,8 +6,21 @@ using Newtonsoft.Json;
 
 namespace BrawlerServer.Utilities
 {
+    public enum Commands : byte
+    {
+        JOIN,
+        CLIENT_JOINED,
+        LEAVE,
+        CLIENT_LEFT,
+        UPDATE,
+        CLIENT_MOVED
+    }
+
     public static class Utilities
     {
+        private static int PacketId = 0;
+        private static uint ClientId = 0;
+
         // handlers per command (the array index is the command)
         private static readonly Dictionary<int, Type> Handlers = new Dictionary<int, Type> {
             { 0, typeof(JoinHandler) },
@@ -53,5 +66,15 @@ namespace BrawlerServer.Utilities
         //{
         //    return Handlers[type];
         //}
+
+        public static int GetPacketId()
+        {
+            return PacketId++;
+        }
+
+        public static uint GetClientId()
+        {
+            return ClientId++;
+        }
     }
 }


### PR DESCRIPTION
[Client] Added unique Id
[Server] Added Reason for client leave
[Server] Now sends Client Join and Leave to every client connected as commands ClientJoined and ClientLeft, closes #2, closes #6 and closes #7
[UpdateHandler] Renamed to MoveHandler as Update is too generic, closes #4
[MoveHandler] Sends back Movement to other clients as ClientMoved with client Id
[Utilities] Added command Enumerator
[Utilities] Added methods to get unique Packet and Client Id
[MoveHandlerTests] Uhm ... Not fully working at the moment, need update